### PR TITLE
Improve appearance of admin

### DIFF
--- a/almanac/apps/registry/admin.py
+++ b/almanac/apps/registry/admin.py
@@ -9,6 +9,8 @@ class CommunityEnergyGroupAdmin(admin.ModelAdmin):
         'name',
         'website',
         'contact_email',
+        'contact_telephone',
+        'postcode',
     )
 
     readonly_fields = (

--- a/almanac/apps/registry/models/community_energy_group.py
+++ b/almanac/apps/registry/models/community_energy_group.py
@@ -79,3 +79,6 @@ class CommunityEnergyGroup(DirtyFieldsMixin, models.Model):
         except ValueError:
             self.latitude, self.longitude = [None, None]
             super(CommunityEnergyGroup, self).save(*args, **kwargs) # Call the "real" save() method.
+
+    def __str__(self):
+        return '{}'.format(self.name)


### PR DESCRIPTION
- show contact phone and postcode in admin list view
- pretty print community energy groups, rather than them being called `CommunityEnergyGroup`