### PR TITLE
Add scripts and config for deploying to production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vagrant/*
 collected_static/*
 
+secrets.sh
 almanac/static/css/site.css*
 
 *__pycache__*

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ test:
 run:
 	./manage.py runserver 0.0.0.0:8009
 
+.PHONY: run_production
+run_production:
+	script/run_production
+
 .PHONY: css
 css: $(SITE_CSS)
 

--- a/_config/nginx/almanac.conf
+++ b/_config/nginx/almanac.conf
@@ -1,0 +1,84 @@
+server {
+  listen 80;
+  server_name almanac.powerpack.org.uk;
+
+  location = / {
+    # Redirect (almost) anything on HTTP to HTTPS
+    return 301 https://$host$request_uri;
+  } 
+}
+
+upstream almanac_gunicorn {
+  # fail_timeout=0 means we always retry an upstream even if it failed
+  # to return a good HTTP response
+
+  server 127.0.0.1:8000 fail_timeout=0;
+}
+
+server {
+    listen 443;
+    server_name almanac.powerpack.org.uk;
+
+    ssl_certificate           /etc/letsencrypt/live/almanac.powerpack.org.uk/fullchain.pem;
+    ssl_certificate_key       /etc/letsencrypt/live/almanac.powerpack.org.uk/privkey.pem;
+
+    ssl on;
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+    ssl_ecdh_curve secp384r1; # Requires nginx >= 1.1.0
+    ssl_session_cache shared:SSL:10m;
+
+    # ssl_session_tickets off; # Requires nginx >= 1.5.9
+
+    ssl_stapling on; # Requires nginx >= 1.3.7
+    ssl_stapling_verify on; # Requires nginx => 1.3.7
+    resolver 213.73.91.35 8.8.8.8 valid=300s;
+    resolver_timeout 5s;
+
+    # https://www.owasp.org/index.php/HTTP_Strict_Transport_Security
+    # TODO
+    # add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload";
+
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+
+    ## https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html#Logjam_(DH_EXPORT)
+    ## To generate, run:
+    ## $ sudo openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
+    ##
+    ssl_dhparam /etc/ssl/certs/dhparam.pem;  # LOGJAM and various others
+
+    access_log            /var/log/nginx/access.log;
+    error_log             /var/log/nginx/error.log;
+
+    # TODO
+    # location ~* ^.+\.(css|js|png|jpg)$ {
+    #     # Set css and js to expire in a very long time
+    #     access_log off;
+    #     expires 7d;
+    # }
+
+    # path for static files
+    root /home/almanac/app/collected_static;
+
+    location / {
+      # checks for static file, if not found proxy to app
+      try_files $uri @proxy_to_app;
+    }
+
+    location @proxy_to_app {
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      # enable this if and only if you use HTTPS
+      # proxy_set_header X-Forwarded-Proto https;
+
+      proxy_set_header Host $http_host;
+
+      # we don't want nginx trying to do something clever with
+      # redirects, we set the Host: header above already.
+      proxy_redirect off;
+      proxy_pass http://almanac_gunicorn;
+    }
+
+}

--- a/_config/nginx/lets-encrypt-acme-challenge.conf
+++ b/_config/nginx/lets-encrypt-acme-challenge.conf
@@ -1,0 +1,12 @@
+server {
+  listen 80;
+
+  location /.well-known/acme-challenge/ {
+    # For the letsencrypt "webroot" plugin
+    # http://letsencrypt.readthedocs.org/en/latest/using.html#webroot
+    #
+    # sudo certbot certonly --webroot -w /etc/letsencrypt/fake-webroot -d <DOMAIN>
+    
+    root /etc/letsencrypt/fake-webroot;
+  }
+}

--- a/_config/supervisor/almanac.conf
+++ b/_config/supervisor/almanac.conf
@@ -1,0 +1,8 @@
+[program:almanac]
+user=almanac
+directory=/home/almanac/app
+command=/home/almanac/script/run_production
+redirect_stderr=true
+autorestart=true
+# http://docs.gunicorn.org/en/stable/signals.html 
+stopsignal=QUIT

--- a/almanac/settings/common.py
+++ b/almanac/settings/common.py
@@ -113,7 +113,7 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = [
     pjoin(PROJECT_BASE_DIR, 'static'),
 ]
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = os.path.join(BASE_DIR, 'collected_static', 'static')
 
 # https://github.com/stefanfoulis/django-phonenumber-field
 PHONENUMBER_DB_FORMAT = 'INTERNATIONAL'

--- a/almanac/settings/common.py
+++ b/almanac/settings/common.py
@@ -113,6 +113,7 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = [
     pjoin(PROJECT_BASE_DIR, 'static'),
 ]
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 # https://github.com/stefanfoulis/django-phonenumber-field
 PHONENUMBER_DB_FORMAT = 'INTERNATIONAL'

--- a/almanac/settings/development.py
+++ b/almanac/settings/development.py
@@ -15,5 +15,4 @@ DATABASES = {
     }
 }
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'collected_static')
 SERVE_STATIC_FILES = True

--- a/almanac/settings/production.py
+++ b/almanac/settings/production.py
@@ -1,0 +1,43 @@
+from .common import *
+
+import os
+
+from django.core.exceptions import ImproperlyConfigured
+
+import dj_database_url
+
+try:
+    SECRET_KEY = os.environ['SECRET_KEY']
+except KeyError:
+    raise ImproperlyConfigured(
+        "In production mode you must specify the `SECRET_KEY` environment "
+        "variable. If you're _definitely not_ running in production it's safe "
+        "to set this to something insecure, eg `export SECRET_KEY=foo`")
+assert len(SECRET_KEY) > 20, "Bad (short) secret key: {}".format(SECRET_KEY)
+
+DEBUG = False
+
+ALLOWED_HOSTS = ['almanac.powerpack.org.uk']
+
+SERVE_STATIC_FILES = False
+
+db_from_env = dj_database_url.config(conn_max_age=500)
+DATABASES = {'default': db_from_env}
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'level': 'DEBUG',
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django': {
+            'handlers': ['console'],
+            'level': 'INFO',
+            'propagate': True,
+        },
+    },
+}

--- a/almanac/wsgi.py
+++ b/almanac/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "almanac.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "almanac.settings.production")
 
 application = get_wsgi_application()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ bng-latlon==1.0
 Django==1.11
 django-dirtyfields==1.2.1
 django-phonenumber-field==1.3.0
+dj-database-url==0.4.2
 gunicorn==19.7.1
 packaging==16.8
 phonenumberslite==8.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ bng-latlon==1.0
 Django==1.11
 django-dirtyfields==1.2.1
 django-phonenumber-field==1.3.0
+gunicorn==19.7.1
 packaging==16.8
 phonenumberslite==8.4.1
 pkg-resources==0.0.0

--- a/script/run_production
+++ b/script/run_production
@@ -1,0 +1,40 @@
+#!/bin/sh -eux
+
+THIS_SCRIPT=$0
+REPO_DIR=$(dirname ${THIS_SCRIPT})/..
+
+setup_django_environment() {
+  export DJANGO_SETTINGS_MODULE=almanac.settings.production
+}
+
+load_secrets_environment_variables() {
+  . ${REPO_DIR}/secrets.sh
+}
+
+
+activate_virtualenv() {
+  . ${REPO_DIR}/../venv/bin/activate
+}
+
+install_requirements() {
+  pip install -r ${REPO_DIR}/requirements.txt
+}
+
+collect_static_files() {
+  ${REPO_DIR}/manage.py collectstatic --no-input --clear
+}
+
+migrate_database() {
+  ${REPO_DIR}/manage.py migrate --no-input
+}
+
+
+setup_django_environment
+load_secrets_environment_variables
+activate_virtualenv
+install_requirements
+collect_static_files
+migrate_database
+
+# Replace current script with gunicorn
+exec gunicorn almanac.wsgi

--- a/secrets.sh.example
+++ b/secrets.sh.example
@@ -1,0 +1,15 @@
+# Populate the environment variables below, then copy to `secrets.sh`
+
+
+## Generate SECRET_KEY with the following command:
+##
+## $ openssl rand -base64 32
+## 
+## Then uncomment the line below:
+
+# export SECRET_KEY="replace-this-with-a-long-random-string"
+
+##
+## Set DATABASE_URL the point to postgres:
+#
+# export DATABASE_URL="postgres://USERNAME:PASSWORD@localhost:5432/DATABASE"


### PR DESCRIPTION
- Add gunicorn server to requirements			978b7c1
- Add dj-database-url for parsing DATABASE_URL			753b422
- Add example secrets.sh.example			9981ba8
- Move STATIC_ROOT from development into common  …			b01eae8
- Move `static` directory inside `collected_static`			fa18802
- Add settings/production, make default in wsgi			c646de4
- Add script/run_production and Makefile entry			c4de404
- Add supervisor config			9a96368
- Add nginx config