### PR TITLE
Make latitude/longitude readonly

### DIFF
--- a/almanac/apps/registry/admin.py
+++ b/almanac/apps/registry/admin.py
@@ -14,6 +14,8 @@ class CommunityEnergyGroupAdmin(admin.ModelAdmin):
     )
 
     readonly_fields = (
+        'latitude',
+        'longitude',
     )
 
     search_fields = (


### PR DESCRIPTION
Currently they are basically slave to the postcode, so don't give the
impression that they should be user editable.